### PR TITLE
Update faScrape.py

### DIFF
--- a/xascraper/modules/fa/faScrape.py
+++ b/xascraper/modules/fa/faScrape.py
@@ -93,7 +93,7 @@ class GetFA(xascraper.modules.scraper_base.ScraperBase, util.captcha2upload.Capt
 
 		# TODO: Proper page parsing, rather then regexes
 
-		regx1 = re.compile(r'[\"\']((?:https:)?//d\.facdn\.net\/[^\'\"]*?)[\"\']>\s?Download\s?</a>')
+		regx1 = re.compile(r'[\"\']((?:https:)?//d\.facdn\.net\/[^\'\"]*?\w)[\"\']>\s?Download\s?</a>')
 		reResult = regx1.search(pgIn)
 
 		if reResult:


### PR DESCRIPTION
Catches an extremely rare critical error caused by very old submissions that have no extension after the final dot due to a corrupt upload. The addition of `\w` ensures the last character of the URL is a letter rather than a dot.