### PR TITLE
Reverts pythonmagic 0.4.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ mprpc==0.1.17
 sqlalchemy_jsonfield==0.8.0
 dill==0.3.0
 tqdm==4.35.0
-python-magic==0.4.15
+python-magic==0.4.14
 webrequest==0.0.58
 
 git+https://github.com/berkerpeksag/astor.git


### PR DESCRIPTION
pythonmagic 0.4.15 throws `ImportError: failed to find libmagic` on Windows installations. The previous version (0.4.14) still works and doesn't seem to have any problems.

https://github.com/Yelp/elastalert/issues/1927#issuecomment-425040424