### PR TITLE
python-magic -> python-magic-bin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ mprpc==0.1.17
 sqlalchemy_jsonfield==0.8.0
 dill==0.3.0
 tqdm==4.35.0
-python-magic==0.4.14
+python-magic-bin==0.4.14
 webrequest==0.0.59
 
 ## git+https://github.com/berkerpeksag/astor.git


### PR DESCRIPTION
because python-magic==0.4.14 no longer exists.