### PR TITLE
Prefer .jpg over the alternative JPEG extensions

### DIFF
--- a/xascraper/modules/scraper_base.py
+++ b/xascraper/modules/scraper_base.py
@@ -59,10 +59,8 @@ def insertExtIfNeeded(fqFName, file_bytes):
 	mime = magic.from_buffer(file_bytes, mime=True)
 	should_ext = mimetypes.guess_extension(mime)
 	if ext != should_ext and should_ext:
-		if ext == '.jfif':
-			ext = '.jpeg'
-		if ext == '.jpe':
-			ext = '.jpeg'
+		if (ext == '.jpe') or (ext == '.jpeg') or (ext == '.jfif'):
+			ext = '.jpg'
 		return root + should_ext
 	return fqFName
 


### PR DESCRIPTION
`.jpg` is the most commonly used JPEG extension, so it makes sense to have this be preferred.